### PR TITLE
Fixes for issues that cause warnings

### DIFF
--- a/Libraries/W7500x_StdPeriph_Driver/inc/w7500x_wztoe.h
+++ b/Libraries/W7500x_StdPeriph_Driver/inc/w7500x_wztoe.h
@@ -763,15 +763,6 @@ uipr[3] = WIZCHIP_READ((WZTOE_UIPR));
  * @param (uint8_t)ir Value to set @ref Sn_IR
  * @sa getSn_IR()
  */
-//#define setSn_IR(sn, ir) \
-//		WIZCHIP_WRITE(WZTOE_Sn_IR(sn), (ir & 0x1F))
-/**
- * @ingroup Socket_register_access_function
- * @brief Get @ref Sn_IR register
- * @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
- * @return uint8_t. Value of @ref Sn_IR.
- * @sa setSn_IR()
- */
 #define getSn_IR(sn) \
     (WIZCHIP_READ(WZTOE_Sn_ISR(sn)) & 0x1F)
 
@@ -954,10 +945,11 @@ uipr[3] = WIZCHIP_READ((WZTOE_UIPR));
     WIZCHIP_WRITE((WZTOE_Sn_DHAR(sn)+0), dhar[3]); \
     WIZCHIP_WRITE((WZTOE_Sn_DHAR(sn)+5), dhar[4]); \
     WIZCHIP_WRITE((WZTOE_Sn_DHAR(sn)+4), dhar[5]); 
+/**
 //17.01.06 by justinkim
 //WIZCHIP_WRITE((WZTOE_Sn_DHAR(sn)+7), dhar[4]); \
     //WIZCHIP_WRITE((WZTOE_Sn_DHAR(sn)+6), dhar[5]); 
-
+*/
 /**
  * @ingroup Socket_register_access_function
  * @brief Get @ref Sn_DHAR register

--- a/Libraries/W7500x_StdPeriph_Driver/src/w7500x_gpio.c
+++ b/Libraries/W7500x_StdPeriph_Driver/src/w7500x_gpio.c
@@ -309,9 +309,6 @@ void GPIO_ResetBits(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
  */
 void GPIO_WriteBit(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, BitAction BitVal)
 {
-    uint32_t temp_gpio_lb;
-    uint32_t temp_gpio_ub;
-
     /* Check the parameters */
     assert_param(IS_GPIO_ALL_PERIPH(GPIOx));
     assert_param(IS_GET_GPIO_PIN(GPIO_Pin));

--- a/Libraries/W7500x_StdPeriph_Driver/src/w7500x_miim.c
+++ b/Libraries/W7500x_StdPeriph_Driver/src/w7500x_miim.c
@@ -134,6 +134,7 @@ FlagStatus PHY_Init(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin_MDC, uint16_t GPIO_Pi
  */
 void PHY_Reset(Reset_Type reset)
 {
+	(void)reset;
 /*
 if (reset == Hardware) {
 #ifdef W7500P

--- a/src/retarget.c
+++ b/src/retarget.c
@@ -86,7 +86,9 @@ void _sys_exit(int return_code) {
 
 __attribute__ ((used)) int _write(int fd, char *ptr, int len)
 {
-    size_t i;
+	(void)fd;
+
+    int i;
     for (i = 0; i < len; i++) {
         UART_SEND_BYTE(ptr[i]);  // call character output function
     }
@@ -121,11 +123,10 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
     uint8_t ch;
 
     do {
-        ch = *str;
+        ch = *str++;
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
     } while (ch != 0);
 }
 
@@ -149,11 +150,10 @@ void S_UartPuts(uint8_t *str)
     uint8_t ch;
 
     do {
-        ch = *str;
+        ch = *str++;
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
     } while (ch != 0);
 }
 


### PR DESCRIPTION
Remove all warnings that occur when 'Enable All Warnings' is set to Yes in the compiler options.